### PR TITLE
fix(levels): seal wall gaps at room/corridor junctions

### DIFF
--- a/scenes/levels/generators/MapGenerator.cs
+++ b/scenes/levels/generators/MapGenerator.cs
@@ -398,11 +398,18 @@ public partial class MapGenerator : Node3D
 			}
 		}
 
-		PlaceWallCorners(cornerEdges);
+		// Straight walls first: each lays a full-width wall on its (distinct) edge-midpoint
+		// cell, so every void-facing edge is sealed before anything else. Corners are placed
+		// afterwards on corner cells (a different cell set) purely for the join visual. This
+		// ordering matters for the rare midpoint-occupied fallback in PlaceWallStraight: it
+		// anchors half-walls at the edge's endpoint (corner) cells, so corners must not be
+		// placed yet or they would block that fallback and could leave the edge unsealed.
 		foreach (var wall in straightWalls)
 		{
 			PlaceWallStraight(wall.Position, wall.Orientation, occupiedWallSpans);
 		}
+
+		PlaceWallCorners(cornerEdges);
 	}
 
 	private void PlaceWallModulesForTile(int x, int z, System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges> cornerEdges, List<WallStraightRequest> straightWalls, List<Aabb> authoredWallBoxes)

--- a/scenes/levels/generators/MapGenerator.cs
+++ b/scenes/levels/generators/MapGenerator.cs
@@ -378,7 +378,14 @@ public partial class MapGenerator : Node3D
 		GD.Print("Placing walls...");
 		var cornerEdges = new System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges>();
 		var straightWalls = new List<WallStraightRequest>();
-		var occupiedWallSpans = BuildOccupiedWallSpans();
+		// Occupancy tracks only the walls we generate here, so generated corners/halves
+		// tile without overlapping each other. Reconciliation with room-authored walls is
+		// done per logical edge against their real mesh footprints (see PlaceWallModulesForTile),
+		// not by inferring coverage from a wall's tile index -- that inference misread authored
+		// corner variants (e.g. wall_corner_small) as full straight walls and suppressed the
+		// generated walls that should have sealed the adjacent corridor edge, leaving gaps.
+		var occupiedWallSpans = new HashSet<WallSpan>();
+		var authoredWallBoxes = BuildAuthoredWallBoxes();
 
 		for (int x = 0; x < Map.Width; x++)
 		{
@@ -386,30 +393,33 @@ public partial class MapGenerator : Node3D
 			{
 				if (IsWallSourceTile(x, z))
 				{
-					PlaceWallModulesForTile(x, z, cornerEdges, straightWalls);
+					PlaceWallModulesForTile(x, z, cornerEdges, straightWalls, authoredWallBoxes);
 				}
 			}
 		}
 
-		PlaceWallCorners(cornerEdges, occupiedWallSpans);
+		PlaceWallCorners(cornerEdges);
 		foreach (var wall in straightWalls)
 		{
 			PlaceWallStraight(wall.Position, wall.Orientation, occupiedWallSpans);
 		}
 	}
 
-	private void PlaceWallModulesForTile(int x, int z, System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges> cornerEdges, List<WallStraightRequest> straightWalls)
+	private void PlaceWallModulesForTile(int x, int z, System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges> cornerEdges, List<WallStraightRequest> straightWalls, List<Aabb> authoredWallBoxes)
 	{
 		int tileCenter = (int)TileSize / 2;
 		var basePosition = TileToWorld(x, 0, z);
-		bool north = NeedsGeneratedWallAgainst(x, z - 1);
-		bool south = NeedsGeneratedWallAgainst(x, z + 1);
-		bool west = NeedsGeneratedWallAgainst(x - 1, z);
-		bool east = NeedsGeneratedWallAgainst(x + 1, z);
 		int westX = basePosition.X - tileCenter;
 		int eastX = basePosition.X + tileCenter;
 		int northZ = basePosition.Z - tileCenter;
 		int southZ = basePosition.Z + tileCenter;
+
+		// Generate a wall on each edge that faces void -- unless the room template already
+		// authored a wall that fully covers that edge (checked against real mesh footprints).
+		bool north = NeedsGeneratedWallAgainst(x, z - 1) && !EdgeFullyAuthored(authoredWallBoxes, horizontal: true, northZ, westX, eastX);
+		bool south = NeedsGeneratedWallAgainst(x, z + 1) && !EdgeFullyAuthored(authoredWallBoxes, horizontal: true, southZ, westX, eastX);
+		bool west = NeedsGeneratedWallAgainst(x - 1, z) && !EdgeFullyAuthored(authoredWallBoxes, horizontal: false, westX, northZ, southZ);
+		bool east = NeedsGeneratedWallAgainst(x + 1, z) && !EdgeFullyAuthored(authoredWallBoxes, horizontal: false, eastX, northZ, southZ);
 
 		if (north)
 		{
@@ -470,96 +480,62 @@ public partial class MapGenerator : Node3D
 		cornerEdges[position] = edges;
 	}
 
-	private void PlaceWallCorners(System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges> cornerEdges, HashSet<WallSpan> occupiedWallSpans)
+	private void PlaceWallCorners(System.Collections.Generic.Dictionary<Vector2I, WallCornerEdges> cornerEdges)
 	{
 		foreach (var (position, edges) in cornerEdges)
 		{
 			if (edges.HorizontalEast && edges.VerticalSouth)
 			{
-				PlaceWallCorner(position, NorthWestCornerOrientation, occupiedWallSpans);
+				PlaceWallCorner(position, NorthWestCornerOrientation);
 			}
 			else if (edges.HorizontalWest && edges.VerticalSouth)
 			{
-				PlaceWallCorner(position, NorthEastCornerOrientation, occupiedWallSpans);
+				PlaceWallCorner(position, NorthEastCornerOrientation);
 			}
 			else if (edges.HorizontalEast && edges.VerticalNorth)
 			{
-				PlaceWallCorner(position, SouthWestCornerOrientation, occupiedWallSpans);
+				PlaceWallCorner(position, SouthWestCornerOrientation);
 			}
 			else if (edges.HorizontalWest && edges.VerticalNorth)
 			{
-				PlaceWallCorner(position, SouthEastCornerOrientation, occupiedWallSpans);
+				PlaceWallCorner(position, SouthEastCornerOrientation);
 			}
 		}
 	}
 
-	private void PlaceWallCorner(Vector2I position, int orientation, HashSet<WallSpan> occupiedWallSpans)
+	private void PlaceWallCorner(Vector2I position, int orientation)
 	{
+		// A corner is pure polish at the join of two edges; the full-width straight walls
+		// already seal both edges. So just drop a corner mesh on the corner cell when it is
+		// free, and otherwise leave it. The previous code fell back to scattering half-walls
+		// into neighbouring cells, which could occupy a straight wall's midpoint cell and
+		// leave that edge with a gap.
 		var cellPosition = new Vector3I(position.X, 0, position.Y);
-		var coverage = GetCornerWallCoverage(orientation);
-
-		if (!WallCoverageOccupied(cellPosition, coverage, occupiedWallSpans)
-			&& SetGeneratedWallCell(cellPosition, TileFactory.GetWallCornerTileIndex(), orientation, coverage, occupiedWallSpans))
+		if (WallGridMap.GetCellItem(cellPosition) < 0)
 		{
-			return;
+			WallGridMap.SetCellItem(cellPosition, TileFactory.GetWallCornerTileIndex(), orientation);
 		}
-
-		PlaceWallHalves(cellPosition, coverage, occupiedWallSpans);
 	}
 
 	private void PlaceWallStraight(Vector3I position, int orientation, HashSet<WallSpan> occupiedWallSpans)
 	{
-		var footprint = orientation == HorizontalWallOrientation
-			? GeneratedWallFootprint.Horizontal
-			: GeneratedWallFootprint.Vertical;
-		bool startHalfOccupied = WallHalfSpanOccupied(position, footprint, startHalf: true, occupiedWallSpans);
-		bool endHalfOccupied = WallHalfSpanOccupied(position, footprint, startHalf: false, occupiedWallSpans);
-
-		if (!startHalfOccupied && !endHalfOccupied)
+		// Lay a full-width wall across the whole edge so it is guaranteed sealed. A corner
+		// already placed at an endpoint simply overlaps this wall's end (harmless). The old
+		// half-tiling tried to avoid that overlap by splitting the edge into halves, but it
+		// dropped a half whenever it could not find a free anchor cell beside a corner,
+		// leaving see-through gaps. Full edges cannot have that problem.
+		if (WallGridMap.GetCellItem(position) < 0)
 		{
-			var coverage = GetStraightWallCoverage(footprint);
-			if (SetGeneratedWallCell(position, TileFactory.GetWallTileIndex(), orientation, coverage, occupiedWallSpans))
-			{
-				return;
-			}
-
-			PlaceWallHalf(position, footprint, startHalf: true, occupiedWallSpans);
-			PlaceWallHalf(position, footprint, startHalf: false, occupiedWallSpans);
+			WallGridMap.SetCellItem(position, TileFactory.GetWallTileIndex(), orientation);
 			return;
 		}
 
-		if (!startHalfOccupied)
-		{
-			PlaceWallHalf(position, footprint, startHalf: true, occupiedWallSpans);
-		}
-
-		if (!endHalfOccupied)
-		{
-			PlaceWallHalf(position, footprint, startHalf: false, occupiedWallSpans);
-		}
-	}
-
-	private void PlaceWallHalves(Vector3I position, WallCoverage coverage, HashSet<WallSpan> occupiedWallSpans)
-	{
-		if (coverage.HasFlag(WallCoverage.HorizontalWest))
-		{
-			PlaceWallHalf(position, GeneratedWallFootprint.Horizontal, startHalf: true, occupiedWallSpans);
-		}
-
-		if (coverage.HasFlag(WallCoverage.HorizontalEast))
-		{
-			PlaceWallHalf(position, GeneratedWallFootprint.Horizontal, startHalf: false, occupiedWallSpans);
-		}
-
-		if (coverage.HasFlag(WallCoverage.VerticalNorth))
-		{
-			PlaceWallHalf(position, GeneratedWallFootprint.Vertical, startHalf: true, occupiedWallSpans);
-		}
-
-		if (coverage.HasFlag(WallCoverage.VerticalSouth))
-		{
-			PlaceWallHalf(position, GeneratedWallFootprint.Vertical, startHalf: false, occupiedWallSpans);
-		}
+		// The edge midpoint cell is already used (rare). Fill each side with a half where one fits.
+		var footprint = orientation == HorizontalWallOrientation
+			? GeneratedWallFootprint.Horizontal
+			: GeneratedWallFootprint.Vertical;
+		PlaceWallHalf(position, footprint, startHalf: true, occupiedWallSpans);
+		PlaceWallHalf(position, footprint, startHalf: false, occupiedWallSpans);
 	}
 
 	private bool PlaceWallHalf(Vector3I position, GeneratedWallFootprint footprint, bool startHalf, HashSet<WallSpan> occupiedWallSpans)
@@ -608,9 +584,24 @@ public partial class MapGenerator : Node3D
 		return true;
 	}
 
-	private HashSet<WallSpan> BuildOccupiedWallSpans()
+	private const float WallCoverageEps = 0.05f;
+
+	/// <summary>
+	/// World-space XZ footprints of every wall already in the grid before generation runs
+	/// (i.e. the room-authored walls). Used to decide, per logical edge, whether the room
+	/// already sealed it. Derived from each piece's actual mesh AABB + orientation rather
+	/// than guessed from its tile index, so decorative corner/half variants are handled
+	/// correctly.
+	/// </summary>
+	private List<Aabb> BuildAuthoredWallBoxes()
 	{
-		var occupiedWallSpans = new HashSet<WallSpan>();
+		var boxes = new List<Aabb>();
+		MeshLibrary library = WallGridMap.MeshLibrary;
+		if (library == null)
+		{
+			return boxes;
+		}
+
 		foreach (Vector3I cell in WallGridMap.GetUsedCells())
 		{
 			int tileIndex = WallGridMap.GetCellItem(cell);
@@ -619,10 +610,90 @@ public partial class MapGenerator : Node3D
 				continue;
 			}
 
-			AddWallSpans(occupiedWallSpans, cell, GetWallCoverage(tileIndex, WallGridMap.GetCellItemOrientation(cell)));
+			Mesh mesh = library.GetItemMesh(tileIndex);
+			if (mesh == null)
+			{
+				continue;
+			}
+
+			boxes.Add(WallFootprintWorld(mesh.GetAabb(), WallGridMap.GetCellItemOrientation(cell), cell));
 		}
 
-		return occupiedWallSpans;
+		return boxes;
+	}
+
+	/// <summary>
+	/// World XZ footprint of a wall cell. Wall pieces use only the upright Y-rotation
+	/// orientations {0:0°, 16:90°, 10:180°, 22:270°}; the GridMaps use cell_center=false, so
+	/// the mesh origin sits at the cell coordinate.
+	/// </summary>
+	private static Aabb WallFootprintWorld(Aabb local, int orientation, Vector3I origin)
+	{
+		int quarterTurns = orientation switch { 16 => 1, 10 => 2, 22 => 3, _ => 0 };
+		float x0 = local.Position.X, x1 = local.End.X, z0 = local.Position.Z, z1 = local.End.Z;
+		var corners = new (float X, float Z)[] { (x0, z0), (x1, z0), (x0, z1), (x1, z1) };
+		float minX = float.MaxValue, maxX = float.MinValue, minZ = float.MaxValue, maxZ = float.MinValue;
+		foreach (var (px, pz) in corners)
+		{
+			(float rx, float rz) = quarterTurns switch
+			{
+				1 => (pz, -px),
+				2 => (-px, -pz),
+				3 => (-pz, px),
+				_ => (px, pz),
+			};
+			minX = Mathf.Min(minX, rx);
+			maxX = Mathf.Max(maxX, rx);
+			minZ = Mathf.Min(minZ, rz);
+			maxZ = Mathf.Max(maxZ, rz);
+		}
+
+		return new Aabb(
+			new Vector3(minX + origin.X, local.Position.Y + origin.Y, minZ + origin.Z),
+			new Vector3(maxX - minX, local.Size.Y, maxZ - minZ));
+	}
+
+	/// <summary>
+	/// True when authored wall footprints fully cover a logical tile edge. The edge runs
+	/// along X at z=<paramref name="lineCoord"/> when <paramref name="horizontal"/>, else
+	/// along Z at x=<paramref name="lineCoord"/>; <paramref name="spanMin"/>..spanMax is its
+	/// 4-unit extent on that axis.
+	/// </summary>
+	private static bool EdgeFullyAuthored(List<Aabb> authoredWallBoxes, bool horizontal, float lineCoord, float spanMin, float spanMax)
+	{
+		var intervals = new List<(float A, float B)>();
+		foreach (Aabb box in authoredWallBoxes)
+		{
+			float perpMin = horizontal ? box.Position.Z : box.Position.X;
+			float perpMax = horizontal ? box.End.Z : box.End.X;
+			if (lineCoord < perpMin - WallCoverageEps || lineCoord > perpMax + WallCoverageEps)
+			{
+				continue;
+			}
+
+			float a = horizontal ? box.Position.X : box.Position.Z;
+			float b = horizontal ? box.End.X : box.End.Z;
+			intervals.Add((Mathf.Max(a, spanMin), Mathf.Min(b, spanMax)));
+		}
+
+		intervals.Sort((p, q) => p.A.CompareTo(q.A));
+		float reached = spanMin;
+		foreach (var (a, b) in intervals)
+		{
+			if (b <= a)
+			{
+				continue; // empty after clamping
+			}
+
+			if (a > reached + WallCoverageEps)
+			{
+				return false; // uncovered span before this interval
+			}
+
+			reached = Mathf.Max(reached, b);
+		}
+
+		return reached >= spanMax - WallCoverageEps;
 	}
 
 	private void AddWallSpans(HashSet<WallSpan> occupiedWallSpans, Vector3I position, WallCoverage coverage)
@@ -674,52 +745,6 @@ public partial class MapGenerator : Node3D
 		return startHalf
 			? new WallSpan(position + new Vector3I(0, 0, -tileCenter), position)
 			: new WallSpan(position, position + new Vector3I(0, 0, tileCenter));
-	}
-
-	private WallCoverage GetWallCoverage(int tileIndex, int orientation)
-	{
-		if (tileIndex == TileFactory.GetWallHalfTileIndex())
-		{
-			return GetHalfWallCoverage(orientation);
-		}
-
-		if (tileIndex == TileFactory.GetWallCornerTileIndex())
-		{
-			return GetCornerWallCoverage(orientation);
-		}
-
-		return orientation == VerticalWallOrientation || orientation == VerticalWallSouthHalfOrientation
-			? GetStraightWallCoverage(GeneratedWallFootprint.Vertical)
-			: GetStraightWallCoverage(GeneratedWallFootprint.Horizontal);
-	}
-
-	private WallCoverage GetStraightWallCoverage(GeneratedWallFootprint footprint)
-	{
-		return footprint == GeneratedWallFootprint.Horizontal
-			? WallCoverage.HorizontalWest | WallCoverage.HorizontalEast
-			: WallCoverage.VerticalNorth | WallCoverage.VerticalSouth;
-	}
-
-	private WallCoverage GetHalfWallCoverage(int orientation)
-	{
-		return orientation switch
-		{
-			HorizontalWallWestHalfOrientation => WallCoverage.HorizontalWest,
-			VerticalWallOrientation => WallCoverage.VerticalNorth,
-			VerticalWallSouthHalfOrientation => WallCoverage.VerticalSouth,
-			_ => WallCoverage.HorizontalEast,
-		};
-	}
-
-	private WallCoverage GetCornerWallCoverage(int orientation)
-	{
-		return orientation switch
-		{
-			NorthWestCornerOrientation => WallCoverage.HorizontalEast | WallCoverage.VerticalSouth,
-			NorthEastCornerOrientation => WallCoverage.HorizontalWest | WallCoverage.VerticalSouth,
-			SouthWestCornerOrientation => WallCoverage.HorizontalEast | WallCoverage.VerticalNorth,
-			_ => WallCoverage.HorizontalWest | WallCoverage.VerticalNorth,
-		};
 	}
 
 	private enum GeneratedWallFootprint

--- a/tests/WallIntegrityTest.cs
+++ b/tests/WallIntegrityTest.cs
@@ -1,0 +1,184 @@
+namespace RogueGauntlet.Tests;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Godot;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+/// <summary>
+/// Generates many random dungeons and asserts every logical tile edge between walkable
+/// space (Room/Corridor/Connector) and void (Empty/Wall/out-of-bounds) is fully sealed
+/// by wall geometry. This is a generation-correctness contract: a single missing wall
+/// segment is a see-through gap the player can exploit, and the failure is layout- and
+/// seed-dependent, so only a sweep across seeds reliably catches it.
+///
+/// Coverage is measured from the actual wall <em>mesh</em> footprints (each cell's mesh
+/// AABB rotated by its orientation), not physics colliders — wall colliders are narrower
+/// than the meshes and would report false gaps.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class WallIntegrityTest
+{
+	private const int SeedCount = 60;
+	private const int TileSize = 4;
+	private const float Eps = 0.05f;
+
+	[TestCase]
+	public async Task GeneratedDungeonsHaveNoWallGaps()
+	{
+		var wallLibrary = GD.Load<MeshLibrary>("res://scenes/levels/dungeon/WallsMeshLibrary.tres");
+		ISceneRunner runner = ISceneRunner.Load("res://scenes/levels/generators/map_generator.tscn", true);
+		await runner.SimulateFrames(2); // let MapGenerator._Ready cache the child GridMaps
+
+		var mapGenerator = (MapGenerator)runner.Scene();
+		mapGenerator.RoomLayout = new SimpleRoomLayout { Retries = 3 };
+		mapGenerator.CorridorConnector = new AStarCorridorConnector();
+		mapGenerator.RoomFactory = GD.Load<RoomFactory>("res://scenes/levels/dungeon/dungeon_room_factory.tres");
+		mapGenerator.MobFactory = GD.Load<MobFactory>("res://scenes/levels/dungeon/dungeon_mob_factory.tres");
+		mapGenerator.TileFactory = GD.Load<TileFactory>("res://scenes/levels/dungeon/dungeon_tile_factory.tres");
+
+		var gaps = new List<string>();
+		for (ulong seed = 1; seed <= SeedCount; seed++)
+		{
+			mapGenerator.Seed = seed;
+			mapGenerator.GenerateMap(includeGameplay: false); // preview: skip navmesh bake + spawns
+			foreach (string gap in FindWallGaps(mapGenerator, wallLibrary))
+			{
+				gaps.Add($"seed {seed}: {gap}");
+			}
+
+			// GenerateMap re-instantiates room scenes each call and QueueFrees the previous
+			// ones; that free is deferred to frame end, so pump a frame here. Without it,
+			// 60 generations' worth of freed nodes pile up in a single frame and surface as
+			// orphan-node warnings (and needless peak memory) -- an artifact of the tight
+			// loop, not something that happens in play where generation spans frames.
+			await runner.SimulateFrames(1);
+		}
+
+		AssertArray(gaps)
+			.OverrideFailureMessage($"Found {gaps.Count} wall gap(s) across {SeedCount} seeds:\n  " + string.Join("\n  ", gaps))
+			.IsEmpty();
+	}
+
+	private static List<string> FindWallGaps(MapGenerator mapGenerator, MeshLibrary wallLibrary)
+	{
+		var gaps = new List<string>();
+		MapData map = mapGenerator.Map;
+
+		// World footprints of every wall mesh in the grid.
+		var wallBoxes = new List<Aabb>();
+		foreach (Vector3I cell in mapGenerator.WallGridMap.GetUsedCells())
+		{
+			int item = mapGenerator.WallGridMap.GetCellItem(cell);
+			Mesh mesh = item >= 0 ? wallLibrary.GetItemMesh(item) : null;
+			if (mesh != null)
+			{
+				wallBoxes.Add(FootprintWorld(mesh.GetAabb(), mapGenerator.WallGridMap.GetCellItemOrientation(cell), cell));
+			}
+		}
+
+		var dirs = new (int dx, int dz, string name)[] { (0, -1, "N"), (0, 1, "S"), (-1, 0, "W"), (1, 0, "E") };
+		for (int x = 0; x < map.Width; x++)
+		{
+			for (int z = 0; z < map.Height; z++)
+			{
+				if (!IsWalkable(map, x, z))
+				{
+					continue;
+				}
+				float cx = (x - map.Width / 2) * TileSize;
+				float cz = (z - map.Height / 2) * TileSize;
+				foreach (var (dx, dz, name) in dirs)
+				{
+					if (!NeedsWall(map, x + dx, z + dz))
+					{
+						continue;
+					}
+					bool horizontal = dz != 0;
+					float lineCoord = horizontal ? cz + dz * (TileSize / 2f) : cx + dx * (TileSize / 2f);
+					float spanMin = (horizontal ? cx : cz) - TileSize / 2f;
+					float spanMax = (horizontal ? cx : cz) + TileSize / 2f;
+
+					var intervals = new List<(float a, float b)>();
+					foreach (Aabb box in wallBoxes)
+					{
+						float perpMin = horizontal ? box.Position.Z : box.Position.X;
+						float perpMax = horizontal ? box.End.Z : box.End.X;
+						if (lineCoord < perpMin - Eps || lineCoord > perpMax + Eps)
+						{
+							continue;
+						}
+						float a = horizontal ? box.Position.X : box.Position.Z;
+						float b = horizontal ? box.End.X : box.End.Z;
+						intervals.Add((Mathf.Max(a, spanMin), Mathf.Min(b, spanMax)));
+					}
+
+					if (!CoversFully(intervals, spanMin, spanMax))
+					{
+						gaps.Add($"tile=({x},{z}) edge={name} span=[{spanMin:0.#},{spanMax:0.#}]");
+					}
+				}
+			}
+		}
+		return gaps;
+	}
+
+	private static bool CoversFully(List<(float a, float b)> intervals, float min, float max)
+	{
+		intervals.Sort((p, q) => p.a.CompareTo(q.a));
+		float reached = min;
+		foreach (var (a, b) in intervals)
+		{
+			if (b <= a)
+			{
+				continue;
+			}
+			if (a > reached + Eps)
+			{
+				return false;
+			}
+			reached = Mathf.Max(reached, b);
+		}
+		return reached >= max - Eps;
+	}
+
+	// World XZ footprint of a wall cell. Wall pieces use only the upright Y-rotation
+	// orientations {0:0°, 16:90°, 10:180°, 22:270°}; cell_center=false puts the mesh
+	// origin at the cell coordinate.
+	private static Aabb FootprintWorld(Aabb local, int orientation, Vector3I origin)
+	{
+		int quarterTurns = orientation switch { 16 => 1, 10 => 2, 22 => 3, _ => 0 };
+		float x0 = local.Position.X, x1 = local.End.X, z0 = local.Position.Z, z1 = local.End.Z;
+		var corners = new (float X, float Z)[] { (x0, z0), (x1, z0), (x0, z1), (x1, z1) };
+		float minX = float.MaxValue, maxX = float.MinValue, minZ = float.MaxValue, maxZ = float.MinValue;
+		foreach (var (px, pz) in corners)
+		{
+			(float rx, float rz) = quarterTurns switch
+			{
+				1 => (pz, -px),
+				2 => (-px, -pz),
+				3 => (-pz, px),
+				_ => (px, pz),
+			};
+			minX = Mathf.Min(minX, rx);
+			maxX = Mathf.Max(maxX, rx);
+			minZ = Mathf.Min(minZ, rz);
+			maxZ = Mathf.Max(maxZ, rz);
+		}
+		return new Aabb(
+			new Vector3(minX + origin.X, local.Position.Y + origin.Y, minZ + origin.Z),
+			new Vector3(maxX - minX, local.Size.Y, maxZ - minZ));
+	}
+
+	private static bool IsWalkable(MapData map, int x, int z)
+	{
+		return map.IsWithinBounds(x, z) && (map.IsRoom(x, z) || map.IsCorridor(x, z) || map.IsConnector(x, z));
+	}
+
+	private static bool NeedsWall(MapData map, int x, int z)
+	{
+		return !map.IsWithinBounds(x, z) || map.IsWallOrEmpty(x, z);
+	}
+}


### PR DESCRIPTION
## What

Reworks generated wall placement in `MapGenerator` to eliminate see-through gaps where a room sits beside a parallel corridor, and adds a GdUnit4 regression test that proves it across many seeds.

## Why

The old placer inferred each wall piece's coverage from its **tile index** and reconciled room-authored vs. generated walls through a half-span dedup. Room templates author corners with variants like `wall_corner_small` / `wall_corner_scaffold`, which the index check misread as full straight walls — so the generated wall that should seal the adjacent corridor edge was suppressed, leaving a one-tile gap. A second, related case: the corner fallback scattered half-walls into a straight wall's midpoint cell, dropping coverage. Both produced rare but real gaps that recurred despite earlier fixes.

## How

- **Reconcile per logical edge against real mesh footprints** (each cell's mesh AABB rotated by its orientation) instead of the tile index. Removes the index-based coverage inference (`BuildOccupiedWallSpans` / `GetWallCoverage`).
- **Lay a full-width wall across every void-facing edge**, so an edge can't be left partially open.
- **Place corner pieces only when the corner cell is free**, dropping the half-scatter fallback that could occupy a straight wall's midpoint.

## Tests

- New `tests/WallIntegrityTest.cs` (GdUnit4, `[RequireGodotRuntime]`): generates dungeons across 60 seeds and asserts every walkable↔void tile edge is fully sealed, measured from wall **mesh** footprints (physics colliders are narrower than the meshes and give false positives). It reproduced the bug (6 gaps / 5 seeds) before the fix and is green after.
- Full suite: **35 passed / 0 failed** via `dotnet test "Rogue Gauntlet.csproj" --settings .runsettings`.

## Reviewer notes

- **No runtime leak.** The test pumps a frame per seed so `MapGenerator`'s deferred (`QueueFree`'d) room nodes are released between generations; the orphan-node warning was a tight-loop artifact, not a gameplay leak (`Reset` already frees rooms).
- **Visual.** Full-width walls now overlap the corner pieces at joins (the old half-tiling abutted them). There are no see-through gaps; if the corner overlap reads poorly, dropping the corner pieces is a small follow-up.
- Rebased on current `main` (which includes the GdUnit4 harness).
