### PR TITLE
feat(combat): melee aim-assist, arc hitboxes, and enemy ranged attacks

### DIFF
--- a/scenes/attacks/AttackController.cs
+++ b/scenes/attacks/AttackController.cs
@@ -12,6 +12,17 @@ public partial class AttackController : Node
 	[Export] public bool DebugDrawEnabled { get; set; } = false;
 	public static bool GlobalDebugDrawEnabled { get; set; } = false;
 
+	/// <summary>
+	/// Maximum distance a melee attack will auto-turn the actor toward a target ("aim assist"), so a
+	/// swing connects as long as the target is roughly in front rather than requiring exact facing.
+	/// </summary>
+	[Export] public float MeleeAimAssistRange { get; set; } = 3.0f;
+
+	/// <summary>
+	/// Half-angle, in degrees, of the melee aim-assist cone measured from the actor's forward.
+	/// </summary>
+	[Export] public float MeleeAimAssistAngle { get; set; } = 90.0f;
+
 	private bool _isAttacking;
 	private float _elapsedTime;
 	private AttackDefinition _currentAttack;
@@ -510,6 +521,36 @@ public partial class AttackController : Node
 		if (node.GetParent() is EnemyBase parentEnemy) return !parentEnemy.IsDead;
 		if (node.GetParent() is Player parentPlayer) return !parentPlayer.IsDead;
 		return true;
+	}
+
+	/// <summary>
+	/// Returns the best target to auto-face for a melee swing: the opponent nearest to the actor's
+	/// forward direction within the aim-assist cone and range, or null when nothing qualifies. Used
+	/// to turn the attacker toward its target so hits do not require pixel-perfect facing.
+	/// </summary>
+	public Node3D FindMeleeAimAssistTarget()
+	{
+		if (_actor == null)
+		{
+			return null;
+		}
+
+		string targetGroup = _actor.IsInGroup("player") ? "enemy" : "player";
+		return GetTree().GetNodesInGroup(targetGroup).OfType<Node3D>()
+			.Where(target => IsValidAimTarget(target) && WithinMeleeAimAssist(target))
+			.OrderBy(GetAimAngle)
+			.ThenBy(target => _actor.GlobalPosition.DistanceTo(target.GlobalPosition))
+			.FirstOrDefault();
+	}
+
+	private bool WithinMeleeAimAssist(Node3D target)
+	{
+		if (_actor.GlobalPosition.DistanceTo(target.GlobalPosition) > MeleeAimAssistRange)
+		{
+			return false;
+		}
+
+		return GetAimAngle(target) <= MeleeAimAssistAngle;
 	}
 
 	private float GetAimAngle(Node3D target)

--- a/scenes/components/MovementComponent.cs
+++ b/scenes/components/MovementComponent.cs
@@ -43,6 +43,13 @@ public partial class MovementComponent : Node
 	private Vector3 _pushDirection = Vector3.Zero;
 	private float _pushStrength = 0.0f;
 
+	// A one-frame facing request that overrides movement-based facing for this physics frame.
+	// Re-issue it every frame (e.g. while attacking) to keep the actor turned toward a target;
+	// stop issuing it and facing falls back to the movement direction. Kept as a per-frame request
+	// so it never lingers and fights normal locomotion.
+	private Vector3 _requestedFacing = Vector3.Zero;
+	private bool _hasRequestedFacing = false;
+
 	public override void _Ready()
 	{
 		LookAtDirection = -Actor.GlobalTransform.Basis.Z;
@@ -63,6 +70,24 @@ public partial class MovementComponent : Node
 	public void SetLookAtDirection(Vector3 lookAtDirection)
 	{
 		LookAtDirection = lookAtDirection.Normalized();
+	}
+
+	/// <summary>
+	/// Requests a smooth turn toward a world-space direction for this physics frame, independent of
+	/// movement. Call it every physics frame while the facing should hold (e.g. during an attack
+	/// wind-up) so a stationary actor still rotates to face its target; it takes priority over the
+	/// movement direction for that frame and clears itself once it is no longer re-issued.
+	/// </summary>
+	public void FaceDirection(Vector3 worldDirection)
+	{
+		worldDirection.Y = 0;
+		if (worldDirection.LengthSquared() < 0.0001f)
+		{
+			return;
+		}
+
+		_requestedFacing = worldDirection.Normalized();
+		_hasRequestedFacing = true;
 	}
 
 	public void Stop()
@@ -145,24 +170,33 @@ public partial class MovementComponent : Node
 
 	private void SmoothRotateToward(double delta)
 	{
-		if (TargetDirection != Vector3.Zero)
+		// An explicit facing request (e.g. attack aim-assist) wins over the movement direction for
+		// this frame; otherwise face where we are moving. Consume the request either way so it does
+		// not linger past the frame it was issued.
+		Vector3 lookAt = _hasRequestedFacing
+			? _requestedFacing
+			: (TargetDirection != Vector3.Zero ? new Vector3(TargetDirection.X, 0, TargetDirection.Z).Normalized() : Vector3.Zero);
+		_hasRequestedFacing = false;
+
+		if (lookAt == Vector3.Zero)
 		{
-			var lookAt = new Vector3(TargetDirection.X, 0, TargetDirection.Z).Normalized();
-			if (lookAt.IsEqualApprox(LookAtDirection))
+			return;
+		}
+
+		if (lookAt.IsEqualApprox(LookAtDirection))
+		{
+			LookAtDirection = lookAt;
+		}
+		else
+		{
+			// Handle the case where lookAt is exactly opposite to LookAtDirection
+			if (lookAt.Dot(LookAtDirection) < -0.999f)
 			{
-				LookAtDirection = lookAt;
+				lookAt += new Vector3(0.001f, 0, 0).Normalized();
 			}
-			else
-			{
-				// Handle the case where lookAt is exactly opposite to LookAtDirection
-				if (lookAt.Dot(LookAtDirection) < -0.999f)
-				{
-					lookAt += new Vector3(0.001f, 0, 0).Normalized();
-				}
-				LookAtDirection = LookAtDirection.Slerp(
-					lookAt, RotationSpeed * (float)delta
-				).Normalized();
-			}
+			LookAtDirection = LookAtDirection.Slerp(
+				lookAt, RotationSpeed * (float)delta
+			).Normalized();
 		}
 	}
 }

--- a/scenes/enemies/EnemyBehaviorComponent.cs
+++ b/scenes/enemies/EnemyBehaviorComponent.cs
@@ -113,7 +113,7 @@ public partial class EnemyBehaviorComponent : Node
 		// The context is the shared blackboard the behavior states read and mutate; the state machine
 		// owns the behavior layer. The timed-action layer (spawn, hit, attack, death) stays on this
 		// host as a gate above the machine - see _PhysicsProcess.
-		_context = new EnemyContext(Actor, MovementComponent, _perception, _navigation, _profile, RequestMeleeAttack);
+		_context = new EnemyContext(Actor, MovementComponent, _perception, _navigation, _profile, RequestMeleeAttack, RequestRangedAttack);
 		_machine = new EnemyStateMachine(_context, new IEnemyState[]
 		{
 			new IdleState(),
@@ -151,6 +151,15 @@ public partial class EnemyBehaviorComponent : Node
 			MovementComponent.Stop();
 			_navigation.ResetStuckTracking();
 
+			// Keep turning to face the target through the attack wind-up so a moving target does not
+			// slip the swing/shot. This is the main fix for enemies whiffing: without it they attack in
+			// whatever direction they were facing when the attack started (movement rotation is off
+			// while stopped).
+			if (IsAttacking && Target != null && GodotObject.IsInstanceValid(Target))
+			{
+				MovementComponent.FaceDirection(Target.GlobalPosition - Actor.GlobalPosition);
+			}
+
 			if (_actionCooldown.Tick(delta))
 			{
 				SetAction(EnemyAction.None);
@@ -172,6 +181,16 @@ public partial class EnemyBehaviorComponent : Node
 	{
 		SetAction(EnemyAction.MeeleAttack);
 		TriggerMeleeAttack();
+	}
+
+	/// <summary>
+	/// Starts a ranged attack through the action layer, mirroring <see cref="RequestMeleeAttack"/>.
+	/// Handed to <see cref="EnemyContext"/> so the Chasing state can request it for caster enemies.
+	/// </summary>
+	private void RequestRangedAttack()
+	{
+		SetAction(EnemyAction.RangedAttack);
+		TriggerRangedAttack();
 	}
 
 	/// <summary>
@@ -231,6 +250,33 @@ public partial class EnemyBehaviorComponent : Node
 		);
 	}
 
+	private void TriggerRangedAttack()
+	{
+		if (_attackController == null)
+		{
+			GD.PushError($"{Actor.Name} cannot start ranged attack without AttackController.");
+			return;
+		}
+
+		AttackDefinition def = _profile.RangedAttackDefinition;
+		if (def == null)
+		{
+			GD.PushError($"{Actor.Name} cannot start ranged attack without a RangedAttackDefinition on its profile.");
+			return;
+		}
+
+		uint targetMask = 4; // Targets player (HurtBoxComponent is on Layer 3 / Mask 4)
+
+		_attackController.StartAttack(
+			def,
+			_profile.RangedAttackMinDamage,
+			_profile.RangedAttackMaxDamage,
+			_profile.RangedAttackAccuracy,
+			_profile.RangedAttackCritChance,
+			targetMask
+		);
+	}
+
 	private AttackDefinition CreateDefaultMeleeAttackDefinition()
 	{
 		var def = new AttackDefinition();
@@ -240,9 +286,12 @@ public partial class EnemyBehaviorComponent : Node
 		def.HitWindowStart = 0.3f * duration;
 		def.HitWindowEnd = 0.7f * duration;
 
+		// Generous frontal wedge anchored to the actor. Combined with facing the target through the
+		// wind-up, this lets an attack connect as long as the player is roughly in front, instead of
+		// requiring the player to be dead-center of a narrow box.
 		def.AttachHitBoxToWeapon = false;
-		def.HitBoxSize = new Vector3(1.5f, 2.2f, 2.2f);
-		def.HitBoxOffset = new Vector3(0.0f, 1.0f, -1.1f);
+		def.HitBoxSize = new Vector3(2.6f, 2.2f, 2.8f);
+		def.HitBoxOffset = new Vector3(0.0f, 1.0f, -1.3f);
 		return def;
 	}
 

--- a/scenes/enemies/EnemyBehaviorProfile.cs
+++ b/scenes/enemies/EnemyBehaviorProfile.cs
@@ -68,6 +68,39 @@ public partial class EnemyBehaviorProfile : Resource
 	[Export] public AttackDefinition MeleeAttackDefinition { get; set; }
 
 	/// <summary>
+	/// Authored ranged attack (projectile) definition. When set, the enemy becomes a caster/shooter:
+	/// it stands off and fires this attack while the target is within <see cref="RangedAttackRange"/>
+	/// and in sight, falling back to melee only when the target closes inside melee range. Leave null
+	/// for melee-only enemies.
+	/// </summary>
+	[Export] public AttackDefinition RangedAttackDefinition { get; set; }
+
+	/// <summary>
+	/// Maximum distance from the target at which the enemy will use its ranged attack.
+	/// </summary>
+	[Export] public float RangedAttackRange { get; set; } = 12.0f;
+
+	/// <summary>
+	/// Accuracy used by this enemy's ranged attack.
+	/// </summary>
+	[Export] public float RangedAttackAccuracy { get; set; } = 0.9f;
+
+	/// <summary>
+	/// Minimum damage dealt by this enemy's ranged attack.
+	/// </summary>
+	[Export] public float RangedAttackMinDamage { get; set; } = 1.0f;
+
+	/// <summary>
+	/// Maximum damage dealt by this enemy's ranged attack.
+	/// </summary>
+	[Export] public float RangedAttackMaxDamage { get; set; } = 4.0f;
+
+	/// <summary>
+	/// Critical hit chance used by this enemy's ranged attack.
+	/// </summary>
+	[Export] public float RangedAttackCritChance { get; set; } = 0.0f;
+
+	/// <summary>
 	/// Maximum distance from its spawn point that the enemy can pick roam destinations.
 	/// </summary>
 	[Export] public float RoamRadius { get; set; } = 8.0f;

--- a/scenes/enemies/ai/ChasingState.cs
+++ b/scenes/enemies/ai/ChasingState.cs
@@ -34,6 +34,15 @@ public sealed class ChasingState : IEnemyState
 			return EnemyBehaviorState.Searching;
 		}
 
+		// Caster enemies stand off and fire while the target is within ranged distance and in sight.
+		// This falls through to the melee chase below when a shot is not viable (target too close, out
+		// of range, or behind cover), so the caster repositions to regain a clear shot. Skipped mid
+		// doorway crossing so firing does not strand the agent on the off-mesh doorway link.
+		if (!crossingDoorway && ctx.CanUseRangedAttack && TryRangedAttack(ctx))
+		{
+			return null;
+		}
+
 		// Retention is reachability-based, not sight-based: as long as the navmesh can reach the
 		// target we keep repathing to its live position, so the enemy pursues around corners and
 		// through doors where it has no line of sight. Skipped while crossing a doorway link, where
@@ -84,5 +93,35 @@ public sealed class ChasingState : IEnemyState
 
 		float distance = ctx.Actor.GlobalPosition.DistanceTo(ctx.Target.GlobalPosition);
 		return distance < ctx.Profile.MeleeAttackRange;
+	}
+
+	/// <summary>
+	/// Ranged "standoff" decision for caster enemies. Fires and holds position (returns true) when the
+	/// target is within ranged range, in sight, and not already inside melee range; returns false to
+	/// let the caller fall back to the melee chase (repositioning to close a gap, regain sight, or
+	/// bite a target that has closed in).
+	/// </summary>
+	private static bool TryRangedAttack(EnemyContext ctx)
+	{
+		if (ctx.Target == null)
+		{
+			return false;
+		}
+
+		float distance = ctx.Actor.GlobalPosition.DistanceTo(ctx.Target.GlobalPosition);
+
+		// Prefer melee when the target is right on top of the caster rather than firing point-blank.
+		if (distance < ctx.Profile.MeleeAttackRange)
+		{
+			return false;
+		}
+
+		if (distance > ctx.Profile.RangedAttackRange || !ctx.HasLineOfSightToTarget())
+		{
+			return false;
+		}
+
+		ctx.RequestRangedAttack();
+		return true;
 	}
 }

--- a/scenes/enemies/ai/EnemyContext.cs
+++ b/scenes/enemies/ai/EnemyContext.cs
@@ -39,6 +39,13 @@ public sealed class EnemyContext
 	/// </summary>
 	public Action RequestMeleeAttack { get; }
 
+	/// <summary>
+	/// Starts a ranged (projectile) attack through the host's timed-action layer, mirroring
+	/// <see cref="RequestMeleeAttack"/>. Only meaningful when the profile has a
+	/// <see cref="EnemyBehaviorProfile.RangedAttackDefinition"/>; see <see cref="CanUseRangedAttack"/>.
+	/// </summary>
+	public Action RequestRangedAttack { get; }
+
 	/// <summary>The player currently being chased, or null when the enemy has no target.</summary>
 	public Node3D Target { get; set; }
 
@@ -62,7 +69,8 @@ public sealed class EnemyContext
 		PerceptionComponent perception,
 		NavigationComponent navigation,
 		EnemyBehaviorProfile profile,
-		Action requestMeleeAttack)
+		Action requestMeleeAttack,
+		Action requestRangedAttack)
 	{
 		Actor = actor;
 		Movement = movement;
@@ -70,7 +78,20 @@ public sealed class EnemyContext
 		Navigation = navigation;
 		Profile = profile;
 		RequestMeleeAttack = requestMeleeAttack;
+		RequestRangedAttack = requestRangedAttack;
 		HomePosition = actor.GlobalPosition;
+	}
+
+	/// <summary>True when this enemy is authored as a shooter (has a ranged attack definition).</summary>
+	public bool CanUseRangedAttack => Profile.RangedAttackDefinition != null;
+
+	/// <summary>
+	/// True when the enemy currently has an unobstructed line of sight to its target. Reuses the
+	/// perception line-of-sight test so ranged enemies do not fire through walls.
+	/// </summary>
+	public bool HasLineOfSightToTarget()
+	{
+		return Target != null && Perception.CanSee(Target);
 	}
 
 	/// <summary>

--- a/scenes/enemies/ai/EnemyContext.cs
+++ b/scenes/enemies/ai/EnemyContext.cs
@@ -91,7 +91,7 @@ public sealed class EnemyContext
 	/// </summary>
 	public bool HasLineOfSightToTarget()
 	{
-		return Target != null && Perception.CanSee(Target);
+		return Target != null && GodotObject.IsInstanceValid(Target) && Perception.CanSee(Target);
 	}
 
 	/// <summary>

--- a/scenes/enemies/wizard/wizard_behavior.tres
+++ b/scenes/enemies/wizard/wizard_behavior.tres
@@ -1,6 +1,22 @@
-[gd_resource type="Resource" script_class="EnemyBehaviorProfile" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="EnemyBehaviorProfile" load_steps=6 format=3]
 
 [ext_resource type="Script" path="res://scenes/enemies/EnemyBehaviorProfile.cs" id="1_profile"]
+[ext_resource type="Script" uid="uid://dirab7d4baxkb" path="res://scenes/attacks/AttackDefinition.cs" id="2_attackdef"]
+[ext_resource type="PackedScene" path="res://scenes/attacks/fireball_projectile.tscn" id="3_projectile"]
+[ext_resource type="PackedScene" path="res://scenes/effects/staff_muzzle_burst_fire.tscn" id="4_muzzle"]
+
+[sub_resource type="Resource" id="Resource_wizard_ranged"]
+script = ExtResource("2_attackdef")
+AnimationId = "ranged_attack"
+HitWindowStart = 0.35
+IsRanged = true
+ProjectileScene = ExtResource("3_projectile")
+MuzzleEffectScene = ExtResource("4_muzzle")
+ProjectilePattern = 0
+ProjectileCount = 1
+ProjectileSpeed = 11.0
+Range = 18.0
+AimingAngle = 60.0
 
 [resource]
 script = ExtResource("1_profile")
@@ -14,6 +30,12 @@ MeleeAttackAccuracy = 0.8
 MeleeAttackMinDamage = 2.0
 MeleeAttackMaxDamage = 6.0
 MeleeAttackCritChance = 0.05
+RangedAttackDefinition = SubResource("Resource_wizard_ranged")
+RangedAttackRange = 14.0
+RangedAttackAccuracy = 1.0
+RangedAttackMinDamage = 3.0
+RangedAttackMaxDamage = 7.0
+RangedAttackCritChance = 0.05
 RoamRadius = 7.0
 RoamPauseMin = 0.75
 RoamPauseMax = 2.5

--- a/scenes/player/PlayerAttackController.cs
+++ b/scenes/player/PlayerAttackController.cs
@@ -7,10 +7,34 @@ public partial class PlayerAttackController : AttackController
 {
 	[Export] public Player Player { get; set; }
 
+	/// <summary>
+	/// Target locked in at the start of the current attack for aim-assist facing, so the player turns
+	/// to face the enemy they are swinging at instead of needing to line up manually. Null when no
+	/// target was in range/cone; the input controller then falls back to the movement facing.
+	/// </summary>
+	private Node3D _aimAssistTarget;
+
 	public override void _Ready()
 	{
 		base._Ready();
 		Player ??= GetParent<Player>();
+	}
+
+	/// <summary>
+	/// Direction the player should face this frame for attack aim-assist, or <see cref="Vector3.Zero"/>
+	/// when there is no locked target. Consumed by <see cref="PlayerInputController"/> while an action
+	/// is playing.
+	/// </summary>
+	public Vector3 GetAimAssistFacing()
+	{
+		if (_aimAssistTarget == null || !GodotObject.IsInstanceValid(_aimAssistTarget))
+		{
+			return Vector3.Zero;
+		}
+
+		Vector3 direction = _aimAssistTarget.GlobalPosition - Player.GlobalPosition;
+		direction.Y = 0;
+		return direction.LengthSquared() > 0.0001f ? direction.Normalized() : Vector3.Zero;
 	}
 
 	public void PerformMeleeAttack()
@@ -51,8 +75,12 @@ public partial class PlayerAttackController : AttackController
 			def = CreateDefaultDefinition(weapon, isSpecial);
 		}
 
-		// Target mask is 24 (detect enemies and damageables)
+		// Target mask is 24 (enemies + props)
 		uint targetMask = 24;
+
+		// Lock an aim-assist target so the player turns toward the enemy they are attacking. This is
+		// what makes melee forgiving: the swing no longer requires exact manual facing.
+		_aimAssistTarget = FindMeleeAimAssistTarget();
 
 		StartAttack(
 			def,
@@ -70,17 +98,27 @@ public partial class PlayerAttackController : AttackController
 		if (weapon != null)
 		{
 			def.AnimationId = weapon.AnimationId;
-			def.AttachHitBoxToWeapon = true;
 			def.HitWindowStart = 0.3f * weapon.PerformDuration;
 			def.HitWindowEnd = 0.7f * weapon.PerformDuration;
 			def.Range = weapon is RangedWeapon ranged ? ranged.Range : 20.0f;
 			def.IsRanged = weapon is RangedWeapon;
-			
+
 			if (weapon is RangedWeapon rangedWeapon)
 			{
 				def.ProjectileSpeed = rangedWeapon.ProjectileSpeed;
 				def.AimingAngle = rangedWeapon.AimingAngle;
 			}
+		}
+
+		if (!def.IsRanged && !isSpecial)
+		{
+			// Forgiving frontal arc anchored to the actor rather than the swinging weapon bone, so the
+			// hit volume is consistent frame-to-frame and connects across a wide wedge in front of the
+			// player. Aim-assist turns the player toward the target, so this only needs to be generous,
+			// not precisely aligned with the weapon.
+			def.AttachHitBoxToWeapon = false;
+			def.HitBoxSize = new Vector3(2.6f, 2.0f, 2.6f);
+			def.HitBoxOffset = new Vector3(0.0f, 0.9f, -1.3f);
 		}
 
 		if (isSpecial)

--- a/scenes/player/PlayerInputController.cs
+++ b/scenes/player/PlayerInputController.cs
@@ -25,7 +25,18 @@ public partial class PlayerInputController : Node
 		if (Player.IsPerformingAction)
 		{
 			MovementComponent.SetInputDirection(Vector3.Zero);
-			MovementComponent.SetLookAtDirection(InputComponent.InputDirection);
+
+			// Aim-assist: while attacking, turn toward the locked target so the player does not have to
+			// face the enemy exactly. With no target, keep facing the movement/aim input as before.
+			Vector3 assistFacing = Player.AttackController?.GetAimAssistFacing() ?? Vector3.Zero;
+			if (assistFacing != Vector3.Zero)
+			{
+				MovementComponent.FaceDirection(assistFacing);
+			}
+			else
+			{
+				MovementComponent.SetLookAtDirection(InputComponent.InputDirection);
+			}
 			return;
 		}
 

--- a/scenes/player/PlayerInputController.cs
+++ b/scenes/player/PlayerInputController.cs
@@ -33,8 +33,10 @@ public partial class PlayerInputController : Node
 			{
 				MovementComponent.FaceDirection(assistFacing);
 			}
-			else
+			else if (InputComponent.InputDirection != Vector3.Zero)
 			{
+				// No aim-assist target: face where the player is aiming. Leave the current facing
+				// untouched when there is no input so we never zero out the stored look direction.
 				MovementComponent.SetLookAtDirection(InputComponent.InputDirection);
 			}
 			return;


### PR DESCRIPTION
## Summary

Makes combat more forgiving and fixes three reported issues: monsters rarely landed hits, the player had to face enemies exactly, and the wizard never shot anything.

Root causes were distinct: enemies swung at stale facing (the movement component only rotates *while moving*, and attackers stop), the player's hitbox was a small box riding the swinging weapon bone with no aim assist, and the enemy **ranged attack path was stubbed scaffolding that nothing ever triggered** — so the wizard fell back to a melee bite.

## Changes

### Aim-assist (no more exact facing)
- `MovementComponent.FaceDirection(dir)` — a per-frame smooth turn request that works while stationary, without disturbing normal movement-based facing.
- `AttackController.FindMeleeAimAssistTarget()` — nearest opponent within a forward cone (`MeleeAimAssistRange` / `MeleeAimAssistAngle`), reusing the existing target-selection helpers.
- `PlayerAttackController` locks the assist target on attack; `PlayerInputController` turns the player toward it through the swing (falling back to input facing when there's no target).

### Arc hitboxes
- Player default melee widened to a **2.6 × 2.0 × 2.6** wedge, anchored to the actor instead of the weapon bone (`AttachHitBoxToWeapon = false`) for frame-consistent hits.
- Enemy default melee widened to **2.6 × 2.2 × 2.8**.

### Enemies track you mid-attack + wizard casts
- Attacking enemies re-face their target through the wind-up — the main fix for whiffing at a moving player.
- Wired the enemy ranged path end-to-end: ranged fields on `EnemyBehaviorProfile` (definition, range, damage, accuracy, crit), `RequestRangedAttack`/`TriggerRangedAttack` in `EnemyBehaviorComponent`, a second delegate + `CanUseRangedAttack`/`HasLineOfSightToTarget()` in `EnemyContext`, and a **line-of-sight standoff** decision in `ChasingState` (fire in range with sight, bite when cornered, otherwise reposition — melee-only enemies are unchanged).
- Authored `wizard_behavior.tres` to fire a fireball from ~14 m (reusing `fireball_projectile.tscn` + fire muzzle burst), still biting at melee range.

## Verification
- `dotnet build` clean (0 errors); existing `EnemyStateMachineTest` unaffected.
- Wizard profile + scene load and read back correctly (ranged sub-resource wired).
- `main.tscn` boots headless — map generates, player spawns, no script errors.
- **Needs play-testing in the editor**: combat feel and the navmesh-gated chase → stand-off → cast chain can't be exercised headless (no navmesh bake).

## Notes for reviewers
- The wizard model has no cast animation, so a ranged attack currently reuses the generic attack (bite) pose plus a muzzle-flash VFX. Functional; a dedicated cast pose is a future polish item.
- Tuning knobs: `MeleeAimAssistRange`/`Angle`, per-attack `HitBoxSize`/`HitBoxOffset`, and the wizard's `RangedAttackRange` + projectile speed/range.
