### PR TITLE
feat: loot beam, magnet pickup, and occlusion x-ray for monsters & loot

### DIFF
--- a/scenes/components/OcclusionXrayComponent.cs
+++ b/scenes/components/OcclusionXrayComponent.cs
@@ -1,0 +1,165 @@
+using Godot;
+using System.Collections.Generic;
+
+/// <summary>
+/// Which global debug toggle governs an <see cref="OcclusionXrayComponent"/>.
+/// </summary>
+public enum XrayCategory
+{
+	Monster,
+	Loot,
+}
+
+/// <summary>
+/// Draws see-through-wall silhouettes for an actor's meshes, the same way <see cref="Door"/>
+/// does for doors: for every <see cref="MeshInstance3D"/> under <see cref="TargetRoot"/> it
+/// builds a duplicate mesh whose shader (<c>door_xray.gdshader</c>) only survives where the
+/// original is occluded by scene geometry, so the actor reads through walls but stays invisible
+/// when already in plain view.
+///
+/// Silhouettes are shown only when the category's global toggle is on
+/// (<see cref="GameDebug"/>) AND the actor is in a discovered room
+/// (<see cref="MapGenerator.IsRevealedAt"/>), matching how the door indicator is gated to
+/// revealed areas.
+/// </summary>
+[GlobalClass]
+public partial class OcclusionXrayComponent : Node
+{
+	private const string XrayShaderPath = "res://scenes/props/door_xray.gdshader";
+	private const int XrayRenderPriority = 8;
+	private const double PollInterval = 0.3;
+
+	/// <summary>Root whose <see cref="MeshInstance3D"/> descendants get silhouettes.</summary>
+	[Export] public NodePath TargetRoot { get; set; }
+	/// <summary>Silhouette tint (alpha is honored; the shader fades it further with distance).</summary>
+	[Export] public Color XrayColor { get; set; } = new(1f, 0.35f, 0.35f, 0.85f);
+	/// <summary>Which debug toggle enables this component.</summary>
+	[Export] public XrayCategory Category { get; set; } = XrayCategory.Monster;
+
+	private static Shader _xrayShader;
+	private static Shader XrayShader => _xrayShader ??= GD.Load<Shader>(XrayShaderPath);
+
+	private readonly List<MeshInstance3D> _silhouettes = new();
+	private Node3D _targetRoot;
+	private MapGenerator _mapGenerator;
+	private HealthComponent _health;
+	private double _pollAccumulator;
+
+	public override void _Ready()
+	{
+		if (Engine.IsEditorHint())
+		{
+			return;
+		}
+
+		_targetRoot = GetNodeOrNull<Node3D>(TargetRoot);
+		if (_targetRoot == null)
+		{
+			GD.PrintErr($"{Name}: OcclusionXrayComponent has no valid TargetRoot.");
+			return;
+		}
+
+		_mapGenerator = this.GetAncestorOrNull<Level>()?.MapGenerator;
+		_health = GetParent()?.GetNodeOrNull<HealthComponent>("HealthComponent");
+
+		BuildSilhouettes(_targetRoot);
+
+		this.SubscribeUntilExit(
+			SignalBus.Instance,
+			bus => bus.RoomEntered += OnRoomEntered,
+			bus => bus.RoomEntered -= OnRoomEntered);
+		this.SubscribeUntilExit(
+			SignalBus.Instance,
+			bus => bus.XraySettingsChanged += OnXraySettingsChanged,
+			bus => bus.XraySettingsChanged -= OnXraySettingsChanged);
+
+		Evaluate();
+	}
+
+	public override void _Process(double delta)
+	{
+		// Actors move, so re-check "is in a discovered room" on a low-frequency poll.
+		// Loot is static and would be covered by RoomEntered alone, but polling keeps
+		// one code path and the cost is a single dictionary lookup.
+		if (_silhouettes.Count == 0)
+		{
+			return;
+		}
+
+		_pollAccumulator += delta;
+		if (_pollAccumulator >= PollInterval)
+		{
+			_pollAccumulator = 0;
+			Evaluate();
+		}
+	}
+
+	/// <summary>
+	/// Creates a silhouette duplicate for every mesh under <paramref name="node"/>. Each
+	/// duplicate is parented next to its source and inherits the source's local transform,
+	/// skin, and skeleton binding, so skinned enemy meshes deform with their animation.
+	/// </summary>
+	private void BuildSilhouettes(Node node)
+	{
+		if (node is MeshInstance3D src && src.Mesh != null)
+		{
+			var silhouette = new MeshInstance3D
+			{
+				Name = $"{src.Name}_Xray",
+				Mesh = src.Mesh,
+				Skin = src.Skin,
+				Skeleton = src.Skeleton,
+				MaterialOverride = CreateMaterial(),
+				CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+				Transform = src.Transform,
+				Visible = false,
+			};
+			src.GetParent().AddChild(silhouette);
+			_silhouettes.Add(silhouette);
+		}
+
+		foreach (Node child in node.GetChildren())
+		{
+			BuildSilhouettes(child);
+		}
+	}
+
+	private ShaderMaterial CreateMaterial()
+	{
+		var material = new ShaderMaterial
+		{
+			Shader = XrayShader,
+			RenderPriority = XrayRenderPriority,
+		};
+		material.SetShaderParameter("xray_color", XrayColor);
+		return material;
+	}
+
+	private bool GlobalFlagEnabled() => Category switch
+	{
+		XrayCategory.Loot => GameDebug.LootXrayEnabled,
+		_ => GameDebug.MonsterXrayEnabled,
+	};
+
+	/// <summary>Recomputes and applies silhouette visibility from the toggle + reveal + alive state.</summary>
+	private void Evaluate()
+	{
+		if (_silhouettes.Count == 0 || _targetRoot == null)
+		{
+			return;
+		}
+
+		bool revealed = _mapGenerator == null || _mapGenerator.IsRevealedAt(_targetRoot.GlobalPosition);
+		bool alive = _health == null || !_health.IsDead;
+		bool visible = GlobalFlagEnabled() && revealed && alive;
+
+		foreach (MeshInstance3D silhouette in _silhouettes)
+		{
+			silhouette.Visible = visible;
+		}
+	}
+
+	private void OnRoomEntered(int roomId) => Evaluate();
+
+	private void OnXraySettingsChanged() => Evaluate();
+}

--- a/scenes/components/OcclusionXrayComponent.cs.uid
+++ b/scenes/components/OcclusionXrayComponent.cs.uid
@@ -1,0 +1,1 @@
+uid://c2wpig74i81r4

--- a/scenes/effects/LootBeam.cs
+++ b/scenes/effects/LootBeam.cs
@@ -1,0 +1,120 @@
+using Godot;
+
+/// <summary>
+/// The pickup cue for dropped loot: a radial floor glow and rising sparks — both additive so the
+/// world's glow blooms them. Everything is tinted to a single <see cref="BeamColor"/> (resolved
+/// from item rarity/type by <see cref="LootVisuals"/>). The floor circle identifies the item and
+/// the sparks add life; the item's own model provides the central visual.
+///
+/// Built entirely in code so each instance owns its own materials (per-item color) without
+/// resource-local-to-scene bookkeeping.
+/// </summary>
+[GlobalClass]
+public partial class LootBeam : Node3D
+{
+	private static Shader _glowShader;
+	private static Shader _additiveShader;
+	private static Shader GlowShader => _glowShader ??= GD.Load<Shader>("res://scenes/effects/shaders/loot_glow.gdshader");
+	private static Shader AdditiveShader => _additiveShader ??= GD.Load<Shader>("res://scenes/effects/shaders/loot_additive.gdshader");
+
+	/// <summary>Tint applied to every part of the beam.</summary>
+	[Export]
+	public Color BeamColor
+	{
+		get;
+		set
+		{
+			field = value;
+			ApplyColor();
+		}
+	} = Colors.White;
+
+	/// <summary>Adds a small real-time light so the beam spills onto nearby geometry.</summary>
+	[Export] public bool EmitLight { get; set; } = true;
+
+	private ShaderMaterial _glowMat;
+	private ShaderMaterial _sparkMat;
+	private OmniLight3D _light;
+
+	public override void _Ready()
+	{
+		BuildGlow();
+		BuildSparks();
+		if (EmitLight)
+		{
+			BuildLight();
+		}
+
+		ApplyColor();
+	}
+
+	private void BuildGlow()
+	{
+		_glowMat = new ShaderMaterial { Shader = GlowShader };
+		var glow = new MeshInstance3D
+		{
+			Name = "Glow",
+			Mesh = new QuadMesh { Size = new Vector2(1.5f, 1.5f) },
+			MaterialOverride = _glowMat,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			RotationDegrees = new Vector3(-90f, 0f, 0f), // lay the quad flat on the floor
+			Position = new Vector3(0f, 0.03f, 0f),
+		};
+		AddChild(glow);
+	}
+
+	private void BuildSparks()
+	{
+		_sparkMat = new ShaderMaterial { Shader = AdditiveShader };
+
+		var process = new ParticleProcessMaterial
+		{
+			Direction = new Vector3(0f, 1f, 0f),
+			Spread = 12f,
+			InitialVelocityMin = 1.3f,
+			InitialVelocityMax = 2.4f,
+			Gravity = new Vector3(0f, 0.6f, 0f), // upward acceleration so sparks stream up and speed away
+			ScaleMin = 0.6f,
+			ScaleMax = 1.2f,
+			EmissionShape = ParticleProcessMaterial.EmissionShapeEnum.Box,
+			EmissionBoxExtents = new Vector3(0.16f, 0.02f, 0.16f),
+		};
+
+		var sparks = new GpuParticles3D
+		{
+			Name = "Sparks",
+			Amount = 26,
+			Lifetime = 1.8,
+			ProcessMaterial = process,
+			DrawPass1 = new SphereMesh { Radius = 0.055f, Height = 0.11f, RadialSegments = 6, Rings = 3 },
+			MaterialOverride = _sparkMat,
+			Explosiveness = 0f,
+			Emitting = true,
+		};
+		AddChild(sparks);
+	}
+
+	private void BuildLight()
+	{
+		_light = new OmniLight3D
+		{
+			Name = "Light",
+			OmniRange = 3.0f,
+			LightEnergy = 0.8f,
+			ShadowEnabled = false,
+			Position = new Vector3(0f, 0.6f, 0f),
+		};
+		AddChild(_light);
+	}
+
+	private void ApplyColor()
+	{
+		Vector3 rgb = new(BeamColor.R, BeamColor.G, BeamColor.B);
+		_glowMat?.SetShaderParameter("beam_color", rgb);
+		_sparkMat?.SetShaderParameter("color", rgb);
+		if (_light != null)
+		{
+			_light.LightColor = BeamColor;
+		}
+	}
+}

--- a/scenes/effects/LootBeam.cs.uid
+++ b/scenes/effects/LootBeam.cs.uid
@@ -1,0 +1,1 @@
+uid://dmrp1j6f5y208

--- a/scenes/effects/LootVisuals.cs
+++ b/scenes/effects/LootVisuals.cs
@@ -1,0 +1,48 @@
+using Godot;
+
+/// <summary>
+/// Maps an item to the color used for its loot beam / glow. Centralized so the whole
+/// palette is tunable in one place. Equipables are colored by rarity (ARPG ladder);
+/// currency and everything else fall back to type/neutral colors.
+/// </summary>
+public static class LootVisuals
+{
+	// Rarity ladder — see EquipableItemRarity.
+	public static readonly Color Common = new("dfe4ea");
+	public static readonly Color Uncommon = new("4caf50");
+	public static readonly Color Rare = new("3b82f6");
+	public static readonly Color Legendary = new("ff9d2e");
+	public static readonly Color Unique = new("a855f7");
+
+	// Type colors for non-equipables.
+	public static readonly Color GoldColor = new("ffcf40");
+	public static readonly Color Neutral = Common;
+
+	/// <summary>
+	/// The beam/glow color for a piece of loot, based on its rarity (equipables) or
+	/// type (currency, everything else).
+	/// </summary>
+	public static Color ResolveColor(Item item)
+	{
+		if (item is EquipableItem equipable)
+		{
+			return RarityColor(equipable.Rarity);
+		}
+
+		if (item is Gold)
+		{
+			return GoldColor;
+		}
+
+		return Neutral;
+	}
+
+	public static Color RarityColor(EquipableItemRarity rarity) => rarity switch
+	{
+		EquipableItemRarity.Uncommon => Uncommon,
+		EquipableItemRarity.Rare => Rare,
+		EquipableItemRarity.Legendary => Legendary,
+		EquipableItemRarity.Unique => Unique,
+		_ => Common,
+	};
+}

--- a/scenes/effects/LootVisuals.cs.uid
+++ b/scenes/effects/LootVisuals.cs.uid
@@ -1,0 +1,1 @@
+uid://bdnb378sxcg7l

--- a/scenes/effects/shaders/loot_additive.gdshader
+++ b/scenes/effects/shaders/loot_additive.gdshader
@@ -1,0 +1,12 @@
+shader_type spatial;
+// Flat additive emissive used for the loot beam's core orb and rising sparks. Bright enough
+// (intensity > 1) that additive blending pushes pixels into the glow threshold to bloom.
+render_mode unshaded, cull_disabled, blend_add, depth_draw_never, shadows_disabled, fog_disabled;
+
+uniform vec3 color : source_color = vec3(1.0, 1.0, 1.0);
+uniform float intensity = 2.0;
+
+void fragment() {
+	ALBEDO = color * intensity;
+	ALPHA = 1.0;
+}

--- a/scenes/effects/shaders/loot_additive.gdshader.uid
+++ b/scenes/effects/shaders/loot_additive.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bfbdhg3kfspfd

--- a/scenes/effects/shaders/loot_glow.gdshader
+++ b/scenes/effects/shaders/loot_glow.gdshader
@@ -1,0 +1,16 @@
+shader_type spatial;
+// Additive radial floor glow ("pool of light") for loot, rendered on a flat QuadMesh.
+// Bright hot center fading to nothing at the quad edge.
+render_mode unshaded, cull_disabled, blend_add, depth_draw_never, shadows_disabled, fog_disabled;
+
+uniform vec3 beam_color : source_color = vec3(1.0, 1.0, 1.0);
+uniform float intensity = 2.0;
+uniform float falloff : hint_range(1.0, 5.0) = 2.0;
+
+void fragment() {
+	// Distance from quad center in UV space: 0 at center, 0.5 at edge midpoints.
+	float r = length(UV - vec2(0.5)) * 2.0;
+	float a = pow(clamp(1.0 - r, 0.0, 1.0), falloff);
+	ALBEDO = beam_color * intensity;
+	ALPHA = a;
+}

--- a/scenes/effects/shaders/loot_glow.gdshader.uid
+++ b/scenes/effects/shaders/loot_glow.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cwsmau485qocm

--- a/scenes/enemies/EnemyBase.cs
+++ b/scenes/enemies/EnemyBase.cs
@@ -38,6 +38,17 @@ public partial class EnemyBase : CharacterBody3D, IDamageable
 		{
 			HurtBoxComponent.DamageFilter = DamageSourceFlags.Player | DamageSourceFlags.Boss | DamageSourceFlags.Environment;
 		}
+
+		// See-through-wall silhouette so a hidden enemy reads from any camera angle. Properties
+		// are set before AddChild so the component builds its silhouettes with them in place.
+		var xray = new OcclusionXrayComponent
+		{
+			Name = "OcclusionXrayComponent",
+			Category = XrayCategory.Monster,
+			XrayColor = new Color(1f, 0.32f, 0.32f, 0.85f),
+			TargetRoot = "../Pivot",
+		};
+		AddChild(xray);
 	}
 
 	public override void _PhysicsProcess(double delta)

--- a/scenes/items/LootableItem.cs
+++ b/scenes/items/LootableItem.cs
@@ -3,7 +3,8 @@ using System;
 
 
 /// <summary>
-/// Represents an item that can be picked up by the player.
+/// Represents an item that can be picked up by the player. Shows a rarity/type-colored loot
+/// beam and, when within magnet range, floats to the player and is collected automatically.
 /// </summary>
 public partial class LootableItem : Node3D
 {
@@ -16,24 +17,41 @@ public partial class LootableItem : Node3D
 	/// </summary>
 	[Export] public int Quantity = 1;
 	/// <summary>
-	/// Custom shader material to apply to the item, i.e. for highlighting.
-	/// </summary>
-	[Export] public ShaderMaterial ShaderMaterial;
-	/// <summary>
 	/// Animate the item.
 	/// </summary>
 	[Export] public bool Animate = true;
+
+	/// <summary>
+	/// Distance at which the item is magnetically pulled to the player (~one floor tile).
+	/// Larger than the pickup collider so it also grabs loot that spawns on top of the player
+	/// or rests on furniture/in chests, which the collider never reaches.
+	/// </summary>
+	[Export] public float MagnetRadius = 4.0f;
+	/// <summary>
+	/// Distance at which the pulled item is actually collected.
+	/// </summary>
+	[Export] public float CollectRadius = 0.6f;
+	/// <summary>Fly speed at the edge of the magnet radius.</summary>
+	[Export] public float MagnetMinSpeed = 4.0f;
+	/// <summary>Fly speed right before collection (the pull accelerates inward).</summary>
+	[Export] public float MagnetMaxSpeed = 18.0f;
+
 	/// <summary>
 	/// Waits for the player to exit first before triggering a pickup.
 	/// This is useful when a player just dropped an item and is still within
 	/// the trigger zone. In that case we want to wait until the player leaves
 	/// before listening for new trigger events.
-	/// 
+	///
 	/// This must be set before the LootableItem is added to the tree!
 	/// </summary>
 	public bool WaitForPlayerExited = false;
 
 	public Node3D Pivot;
+
+	private Player _player;
+	private bool _armed;
+	private bool _collected;
+	private bool _pickupBlocked;
 
 	public override void _Ready()
 	{
@@ -73,6 +91,9 @@ public partial class LootableItem : Node3D
 		Pivot.AddChild(itemScene);
 		Pivot.RotateY((float)(GD.Randf() * 2 * Math.PI));
 
+		AddLootBeam();
+		AddXray();
+
 		// FIXME: Hardcoded check for gold is not ideal
 		if (Item is Gold || !Animate)
 		{
@@ -85,17 +106,90 @@ public partial class LootableItem : Node3D
 		}
 	}
 
+	public override void _Process(double delta)
+	{
+		if (Engine.IsEditorHint() || _collected || Item == null)
+		{
+			return;
+		}
+
+		if (_player == null || !GodotObject.IsInstanceValid(_player))
+		{
+			_player = GetTree().GetFirstNodeInGroup("player") as Player;
+			if (_player == null)
+			{
+				return;
+			}
+		}
+
+		Vector3 target = _player.GlobalPosition + Vector3.Up * 0.8f;
+		float dist = GlobalPosition.DistanceTo(target);
+
+		// A just-dropped item stays put until the player steps out of range once, so it
+		// isn't instantly re-collected while still standing on the drop.
+		if (!_armed)
+		{
+			if (!WaitForPlayerExited || dist > MagnetRadius)
+			{
+				_armed = true;
+			}
+			else
+			{
+				return;
+			}
+		}
+
+		// Inventory was full on the last attempt: stop yanking until the player leaves and
+		// comes back, so a full pack doesn't glue the item to them.
+		if (_pickupBlocked)
+		{
+			if (dist > MagnetRadius)
+			{
+				_pickupBlocked = false;
+			}
+			return;
+		}
+
+		if (dist <= CollectRadius)
+		{
+			TryCollect(_player);
+			return;
+		}
+
+		if (dist <= MagnetRadius)
+		{
+			float nearness = 1f - Mathf.Clamp(dist / MagnetRadius, 0f, 1f);
+			float speed = Mathf.Lerp(MagnetMinSpeed, MagnetMaxSpeed, nearness);
+			GlobalPosition = GlobalPosition.MoveToward(target, speed * (float)delta);
+		}
+	}
+
+	private void AddLootBeam()
+	{
+		var beam = new LootBeam { Name = "LootBeam", BeamColor = LootVisuals.ResolveColor(Item) };
+		AddChild(beam);
+	}
+
+	private void AddXray()
+	{
+		Color color = LootVisuals.ResolveColor(Item);
+		color.A = 0.85f;
+		var xray = new OcclusionXrayComponent
+		{
+			Name = "OcclusionXrayComponent",
+			Category = XrayCategory.Loot,
+			XrayColor = color,
+			TargetRoot = "../Pivot",
+		};
+		AddChild(xray);
+	}
+
 	private void UpdateItemNodeProperties(Node node)
 	{
 		if (node is VisualInstance3D visu)
 		{
 			visu.Layers = 0;
 			visu.SetLayerMaskValue(6, true);
-		}
-
-		if (node is MeshInstance3D mesh)
-		{
-			mesh.MaterialOverlay = ShaderMaterial;
 		}
 
 		foreach (Node child in node.GetChildren())
@@ -108,10 +202,30 @@ public partial class LootableItem : Node3D
 	{
 		if (body is Player player)
 		{
-			if (player.PickupItem(Item, Quantity))
-			{
-				QueueFree();
-			}
+			TryCollect(player);
+		}
+	}
+
+	/// <summary>
+	/// Attempts to add the item to the player's inventory. Idempotent (guarded by
+	/// <see cref="_collected"/>) so the magnet and the collider fallback can't double-collect.
+	/// A failed pickup (e.g. full inventory) blocks further pulls until the player leaves range.
+	/// </summary>
+	private void TryCollect(Player player)
+	{
+		if (_collected || player == null)
+		{
+			return;
+		}
+
+		if (player.PickupItem(Item, Quantity))
+		{
+			_collected = true;
+			QueueFree();
+		}
+		else
+		{
+			_pickupBlocked = true;
 		}
 	}
 }

--- a/scenes/items/lootable_item.tscn
+++ b/scenes/items/lootable_item.tscn
@@ -1,16 +1,7 @@
-[gd_scene load_steps=9 format=3 uid="uid://ccltoxuycom37"]
+[gd_scene load_steps=7 format=3 uid="uid://ccltoxuycom37"]
 
 [ext_resource type="Script" uid="uid://bjnjjpaq5mwlp" path="res://scenes/items/LootableItem.cs" id="1_an4ny"]
 [ext_resource type="PackedScene" uid="uid://d2l47r6atc27d" path="res://scenes/components/trigger_component.tscn" id="2_an4ny"]
-[ext_resource type="Shader" uid="uid://buuj0l35p658e" path="res://scenes/effects/shaders/highlight_item.gdshader" id="2_sc28g"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_jws22"]
-render_priority = 0
-shader = ExtResource("2_sc28g")
-shader_parameter/shine_color = Color(1, 1, 1, 1)
-shader_parameter/cycle_interval = 1.0
-shader_parameter/shine_speed = 3.0
-shader_parameter/shine_width = 3.0
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_gwbx5"]
 
@@ -78,7 +69,6 @@ _data = {
 
 [node name="LootableItem" type="Node3D"]
 script = ExtResource("1_an4ny")
-ShaderMaterial = SubResource("ShaderMaterial_jws22")
 
 [node name="Pivot" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)

--- a/scenes/levels/generators/MapGenerator.cs
+++ b/scenes/levels/generators/MapGenerator.cs
@@ -1859,6 +1859,16 @@ public partial class MapGenerator : Node3D
 		return _tileToRoom.TryGetValue(tile, out var id) ? id : -1;
 	}
 
+	/// <summary>
+	/// Whether the tile under the given world position has been uncovered by the fog
+	/// reveal. Used to gate monster/loot x-ray silhouettes to discovered areas, the
+	/// same way <see cref="HasRevealedNeighbor"/> gates the door indicator.
+	/// </summary>
+	public bool IsRevealedAt(Vector3 worldPosition)
+	{
+		return _revealedTiles.Contains(WorldToTile(worldPosition));
+	}
+
 	private Vector3I TileToWorld(Vector3I tile)
 	{
 		return TileToWorld(tile.X, tile.Y, tile.Z);

--- a/scenes/props/Door.cs
+++ b/scenes/props/Door.cs
@@ -34,6 +34,11 @@ public partial class Door : Node3D
 			_interactiveComponent = GetNode<InteractiveComponent>("InteractiveComponent");
 			_interactiveComponent.Interacted += OnInteract;
 			CreateIndicator();
+
+			this.SubscribeUntilExit(
+				SignalBus.Instance,
+				bus => bus.XraySettingsChanged += RefreshIndicator,
+				bus => bus.XraySettingsChanged -= RefreshIndicator);
 		}
 
 		Update();
@@ -89,9 +94,19 @@ public partial class Door : Node3D
 	public void SetIndicatorVisible(bool allowed)
 	{
 		_indicatorAllowed = allowed;
+		RefreshIndicator();
+	}
+
+	/// <summary>
+	/// Applies the current indicator visibility: shown only when the area is discovered,
+	/// the door is closed, and the door x-ray toggle is enabled. The shader still decides
+	/// when it actually renders (only where occluded).
+	/// </summary>
+	private void RefreshIndicator()
+	{
 		if (_xray != null)
 		{
-			_xray.Visible = allowed && !IsOpen;
+			_xray.Visible = _indicatorAllowed && !IsOpen && GameDebug.DoorXrayEnabled;
 		}
 	}
 
@@ -113,7 +128,7 @@ public partial class Door : Node3D
 		_interactiveComponent.IsInteractive = false;
 		_collisionShape.Disabled = true;
 		IsOpen = true;
-		_xray.Visible = false; // No indicator needed once the door is open.
+		RefreshIndicator(); // No indicator needed once the door is open.
 		SignalBus.EmitDoorOpened(this);
 
 		var tween = CreateTween();
@@ -137,7 +152,7 @@ public partial class Door : Node3D
 		_isAnimating = true;
 		_interactiveComponent.IsInteractive = false;
 		IsOpen = false;
-		_xray.Visible = _indicatorAllowed; // Shader decides when it actually appears.
+		RefreshIndicator(); // Shader decides when it actually appears.
 		SignalBus.EmitDoorClosed(this);
 
 		var tween = CreateTween();

--- a/scenes/ui/DebugMenu.cs
+++ b/scenes/ui/DebugMenu.cs
@@ -14,6 +14,9 @@ public partial class DebugMenu : HBoxContainer
 	private const int ToggleNavigationId = 6;
 	private const int ToggleCombatLogsId = 7;
 	private const int ToggleAiLogsId = 8;
+	private const int ToggleDoorXrayId = 9;
+	private const int ToggleMonsterXrayId = 10;
+	private const int ToggleLootXrayId = 11;
 
 	[Export] public Godot.Collections.Array<Item> SpawnableItems { get; set; } = [];
 
@@ -68,6 +71,9 @@ public partial class DebugMenu : HBoxContainer
 		_debugMenu.AddCheckItem("Navigation", ToggleNavigationId);
 		_debugMenu.AddCheckItem("Combat logs", ToggleCombatLogsId);
 		_debugMenu.AddCheckItem("AI logs", ToggleAiLogsId);
+		_debugMenu.AddCheckItem("Door x-ray", ToggleDoorXrayId);
+		_debugMenu.AddCheckItem("Monster x-ray", ToggleMonsterXrayId);
+		_debugMenu.AddCheckItem("Loot x-ray", ToggleLootXrayId);
 		_debugMenu.AddItem("Reveal map", RevealMapId);
 		_debugMenu.AddItem("Restart level", RestartLevelId);
 		_debugMenu.AddSeparator();
@@ -92,6 +98,9 @@ public partial class DebugMenu : HBoxContainer
 
 		SetChecked(ToggleCombatLogsId, GameDebug.CombatLogsEnabled);
 		SetChecked(ToggleAiLogsId, GameDebug.AiLogsEnabled);
+		SetChecked(ToggleDoorXrayId, GameDebug.DoorXrayEnabled);
+		SetChecked(ToggleMonsterXrayId, GameDebug.MonsterXrayEnabled);
+		SetChecked(ToggleLootXrayId, GameDebug.LootXrayEnabled);
 	}
 
 	private void OnDebugMenuPressed(long id)
@@ -109,6 +118,21 @@ public partial class DebugMenu : HBoxContainer
 				break;
 			case ToggleAiLogsId:
 				SetAiLogsEnabled(!GameDebug.AiLogsEnabled);
+				break;
+			case ToggleDoorXrayId:
+				GameDebug.DoorXrayEnabled = !GameDebug.DoorXrayEnabled;
+				SetChecked(ToggleDoorXrayId, GameDebug.DoorXrayEnabled);
+				SignalBus.EmitXraySettingsChanged();
+				break;
+			case ToggleMonsterXrayId:
+				GameDebug.MonsterXrayEnabled = !GameDebug.MonsterXrayEnabled;
+				SetChecked(ToggleMonsterXrayId, GameDebug.MonsterXrayEnabled);
+				SignalBus.EmitXraySettingsChanged();
+				break;
+			case ToggleLootXrayId:
+				GameDebug.LootXrayEnabled = !GameDebug.LootXrayEnabled;
+				SetChecked(ToggleLootXrayId, GameDebug.LootXrayEnabled);
+				SignalBus.EmitXraySettingsChanged();
 				break;
 			case RevealMapId:
 				RevealMap();

--- a/scripts/GameDebug.cs
+++ b/scripts/GameDebug.cs
@@ -8,6 +8,15 @@ public static class GameDebug
 	public static bool CombatLogsEnabled { get; set; } = false;
 	public static bool AiLogsEnabled { get; set; } = false;
 
+	/// <summary>
+	/// See-through-wall x-ray silhouettes. Each is a play/accessibility aid, on by
+	/// default and toggleable from the in-game debug menu. The silhouettes still only
+	/// render where occluded and (for monsters/loot) only in discovered rooms.
+	/// </summary>
+	public static bool DoorXrayEnabled { get; set; } = true;
+	public static bool MonsterXrayEnabled { get; set; } = true;
+	public static bool LootXrayEnabled { get; set; } = true;
+
 	public static void Combat(string message)
 	{
 		if (CombatLogsEnabled)

--- a/scripts/SignalBus.cs
+++ b/scripts/SignalBus.cs
@@ -50,6 +50,10 @@ public partial class SignalBus : Node
     [Signal] public delegate void DoorClosedEventHandler(Node3D door);
     public static void EmitDoorClosed(Node3D door) => Instance?.EmitSignalDoorClosed(door);
 
+    /// <summary>Fired when an x-ray toggle changes in the debug menu so silhouettes refresh.</summary>
+    [Signal] public delegate void XraySettingsChangedEventHandler();
+    public static void EmitXraySettingsChanged() => Instance?.EmitSignalXraySettingsChanged();
+
     public override void _Ready()
     {
         // Ensure this is the only instance


### PR DESCRIPTION
## Summary

Three visibility/pickup improvements to the dungeon crawl.

### 🔦 Loot beam
Replaces the faint white "shine" with a **rarity/type-colored floor glow + rising sparks** (`LootBeam`, colored via `LootVisuals`). Additive, so the world's glow blooms it; the item's own model stays the central visual.

### 🧲 Magnet pickup
`LootableItem` now pulls loot toward the player within ~one floor tile and auto-collects it, replacing the collider-only pickup. This fixes:
- loot that spawned on top of the player (collected immediately), and
- loot resting on furniture / in chests that the collider could never reach.

Full-inventory and just-dropped cases are handled; the collider remains as an idempotent fallback.

### 👁️ Occlusion x-ray for monsters & loot
New reusable `OcclusionXrayComponent` draws see-through-wall silhouettes for monsters and loot — the same technique the doors already use (`door_xray.gdshader`), so a hidden monster/item reads from any camera angle. Silhouettes are gated to **discovered rooms only** (via the new `MapGenerator.IsRevealedAt`), preserving fog-of-war surprise.

Door, monster, and loot x-ray each have a **debug-menu toggle** (`GameDebug` flags + `SignalBus.XraySettingsChanged`), all **on by default**.

## Files of note
- `scenes/effects/LootBeam.cs`, `scenes/effects/LootVisuals.cs`, `scenes/effects/shaders/loot_glow.gdshader`, `loot_additive.gdshader`
- `scenes/components/OcclusionXrayComponent.cs`
- `scenes/items/LootableItem.cs` (beam + x-ray + magnet)
- `scenes/enemies/EnemyBase.cs`, `scenes/props/Door.cs`, `scenes/ui/DebugMenu.cs`
- `scripts/GameDebug.cs`, `scripts/SignalBus.cs`, `scenes/levels/generators/MapGenerator.cs`

## Verification
- `dotnet build` — clean in both **Debug** and **ExportRelease**.
- Headless `main.tscn` smoke — map generates, player + 6 enemies spawn, no errors from the new code (only the known headless navmesh-bake limitation + shutdown leak noise).
- **Visual checks** via a temporary windowed screenshot harness (since headless renders blank): confirmed the per-rarity loot glow + rising sparks, and that the monster x-ray silhouette shows through a wall **and follows skinned animation** (posed, not rest). Harness was removed afterward.

## Notes / tunables
- Palette lives in `LootVisuals` (rarity ladder + gold); beam/magnet feel are exports on `LootBeam`/`LootableItem`.
- The loot glow telegraphs rarity even for unidentified items — trivial to switch unidentified → neutral in `LootVisuals` if that's preferred.
