### PR TITLE
fix(xray): stop monster & loot silhouettes x-raying through themselves

### DIFF
--- a/scenes/components/OcclusionXrayComponent.cs
+++ b/scenes/components/OcclusionXrayComponent.cs
@@ -11,21 +11,24 @@ public enum XrayCategory
 }
 
 /// <summary>
-/// Draws see-through-wall silhouettes for an actor's meshes, the same way <see cref="Door"/>
-/// does for doors: for every <see cref="MeshInstance3D"/> under <see cref="TargetRoot"/> it
-/// builds a duplicate mesh whose shader (<c>door_xray.gdshader</c>) only survives where the
-/// original is occluded by scene geometry, so the actor reads through walls but stays invisible
-/// when already in plain view.
+/// Draws see-through-wall silhouettes for an actor's meshes: for every <see cref="MeshInstance3D"/>
+/// under <see cref="TargetRoot"/> it builds two drawn-on-top duplicates — a stencil "mask" and the
+/// visible x-ray. The mask marks the pixels where the actor is actually visible; the x-ray then
+/// draws only where the actor is hidden (stencil != 1). Because the gate is per-pixel rather than
+/// per-fragment, the actor never x-rays through its own body, regardless of how deep or complex
+/// it is (see the two <c>occlusion_xray*.gdshader</c> files).
 ///
-/// Silhouettes are shown only when the category's global toggle is on
-/// (<see cref="GameDebug"/>) AND the actor is in a discovered room
-/// (<see cref="MapGenerator.IsRevealedAt"/>), matching how the door indicator is gated to
-/// revealed areas.
+/// Silhouettes are shown only when the category's global toggle is on (<see cref="GameDebug"/>)
+/// AND the actor is in a discovered room (<see cref="MapGenerator.IsRevealedAt"/>), matching how
+/// the door indicator is gated to revealed areas.
 /// </summary>
 [GlobalClass]
 public partial class OcclusionXrayComponent : Node
 {
-	private const string XrayShaderPath = "res://scenes/props/door_xray.gdshader";
+	private const string MaskShaderPath = "res://scenes/effects/shaders/occlusion_xray_mask.gdshader";
+	private const string XrayShaderPath = "res://scenes/effects/shaders/occlusion_xray.gdshader";
+	// Transparent draw order: every mask must render (and write its stencil) before any x-ray reads it.
+	private const int MaskRenderPriority = 0;
 	private const int XrayRenderPriority = 8;
 	private const double PollInterval = 0.3;
 
@@ -36,7 +39,9 @@ public partial class OcclusionXrayComponent : Node
 	/// <summary>Which debug toggle enables this component.</summary>
 	[Export] public XrayCategory Category { get; set; } = XrayCategory.Monster;
 
+	private static Shader _maskShader;
 	private static Shader _xrayShader;
+	private static Shader MaskShader => _maskShader ??= GD.Load<Shader>(MaskShaderPath);
 	private static Shader XrayShader => _xrayShader ??= GD.Load<Shader>(XrayShaderPath);
 
 	private readonly List<MeshInstance3D> _silhouettes = new();
@@ -95,27 +100,16 @@ public partial class OcclusionXrayComponent : Node
 	}
 
 	/// <summary>
-	/// Creates a silhouette duplicate for every mesh under <paramref name="node"/>. Each
-	/// duplicate is parented next to its source and inherits the source's local transform,
-	/// skin, and skeleton binding, so skinned enemy meshes deform with their animation.
+	/// Creates the mask + x-ray duplicate pair for every mesh under <paramref name="node"/>. Each
+	/// duplicate is parented next to its source and inherits the source's local transform, skin,
+	/// and skeleton binding, so skinned enemy meshes deform with their animation.
 	/// </summary>
 	private void BuildSilhouettes(Node node)
 	{
 		if (node is MeshInstance3D src && src.Mesh != null)
 		{
-			var silhouette = new MeshInstance3D
-			{
-				Name = $"{src.Name}_Xray",
-				Mesh = src.Mesh,
-				Skin = src.Skin,
-				Skeleton = src.Skeleton,
-				MaterialOverride = CreateMaterial(),
-				CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
-				Transform = src.Transform,
-				Visible = false,
-			};
-			src.GetParent().AddChild(silhouette);
-			_silhouettes.Add(silhouette);
+			AddDuplicate(src, CreateMaskMaterial());
+			AddDuplicate(src, CreateXrayMaterial());
 		}
 
 		foreach (Node child in node.GetChildren())
@@ -124,7 +118,30 @@ public partial class OcclusionXrayComponent : Node
 		}
 	}
 
-	private ShaderMaterial CreateMaterial()
+	private void AddDuplicate(MeshInstance3D src, ShaderMaterial material)
+	{
+		var duplicate = new MeshInstance3D
+		{
+			Name = $"{src.Name}_Xray",
+			Mesh = src.Mesh,
+			Skin = src.Skin,
+			Skeleton = src.Skeleton,
+			MaterialOverride = material,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			Transform = src.Transform,
+			Visible = false,
+		};
+		src.GetParent().AddChild(duplicate);
+		_silhouettes.Add(duplicate);
+	}
+
+	private ShaderMaterial CreateMaskMaterial() => new()
+	{
+		Shader = MaskShader,
+		RenderPriority = MaskRenderPriority,
+	};
+
+	private ShaderMaterial CreateXrayMaterial()
 	{
 		var material = new ShaderMaterial
 		{

--- a/scenes/effects/shaders/occlusion_xray.gdshader
+++ b/scenes/effects/shaders/occlusion_xray.gdshader
@@ -1,0 +1,21 @@
+shader_type spatial;
+// See-through-wall silhouette for an actor (monster/loot). Drawn on top of everything, but the
+// stencil written by the companion mask (occlusion_xray_mask.gdshader) makes it appear ONLY where
+// the actor is hidden (stencil != 1). So an actor in plain view shows nothing, and — because the
+// gate is per-pixel — its own body parts never x-ray through each other. Alpha fades with distance
+// so far actors stay quiet.
+render_mode unshaded, cull_disabled, depth_draw_never, depth_test_disabled;
+stencil_mode read, compare_not_equal, 1;
+
+uniform vec4 xray_color : source_color = vec4(1.0, 0.35, 0.35, 0.85);
+uniform float fade_near = 16.0;
+uniform float fade_far = 34.0;
+
+void fragment() {
+	float fade = 1.0 - smoothstep(fade_near, fade_far, length(VERTEX));
+	if (fade <= 0.0) {
+		discard;
+	}
+	ALBEDO = xray_color.rgb;
+	ALPHA = xray_color.a * fade;
+}

--- a/scenes/effects/shaders/occlusion_xray.gdshader.uid
+++ b/scenes/effects/shaders/occlusion_xray.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bd2b82olqoy8n

--- a/scenes/effects/shaders/occlusion_xray_mask.gdshader
+++ b/scenes/effects/shaders/occlusion_xray_mask.gdshader
@@ -1,0 +1,26 @@
+shader_type spatial;
+// Stencil mask for the occlusion x-ray. Marks (stencil = 1) every screen pixel where this
+// actor's front-most surface is actually visible — i.e. not hidden by a wall. Drawn on top with
+// no visible color (additive black); a fragment is discarded where scene geometry is in front of
+// it, so only the genuinely visible fragments write the stencil.
+//
+// The companion x-ray pass then draws only where stencil != 1, which is exactly where the actor
+// is hidden. Because the test is per-pixel (via the shared stencil) rather than per-fragment,
+// the actor's own body parts never x-ray through each other — no matter how deep the body is.
+render_mode unshaded, cull_disabled, depth_draw_never, depth_test_disabled, blend_add;
+stencil_mode write, compare_always, 1;
+
+// Nearest filtering: mipmapped/linear sampling of depth returns averaged values.
+uniform sampler2D depth_texture : hint_depth_texture, filter_nearest;
+uniform float occlusion_bias = 0.001;
+
+void fragment() {
+	float scene_depth = texture(depth_texture, SCREEN_UV).x;
+	// Reversed-Z: nearer geometry has a LARGER value. If something is already drawn in front of
+	// this fragment, it is not the visible surface, so don't mark this pixel as visible.
+	if (scene_depth > FRAGCOORD.z + occlusion_bias) {
+		discard;
+	}
+	ALBEDO = vec3(0.0);
+	ALPHA = 1.0;
+}

--- a/scenes/effects/shaders/occlusion_xray_mask.gdshader.uid
+++ b/scenes/effects/shaders/occlusion_xray_mask.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bla5j8mlpah88


### PR DESCRIPTION
## Problem

Follow-up to #24. Monster (and loot) x-ray silhouettes self-occluded: the shader compared the **full scene depth per-fragment**, which includes the actor's own body, so a part behind the torso registered as "occluded" by the front of the same actor and x-rayed through it — worst on deep, complex models (e.g. the orc).

## Fix

The x-ray is now gated by a **stencil mask** instead of a per-fragment depth compare — the correct, tuning-free solution (Godot 4.4+ stencil shaders).

For each actor mesh, `OcclusionXrayComponent` builds two drawn-on-top duplicates:

1. **Mask** (`occlusion_xray_mask.gdshader`) — writes `stencil = 1` at every screen pixel where the actor's front-most surface is actually visible (discards fragments that are behind scene geometry).
2. **X-ray** (`occlusion_xray.gdshader`) — draws the colored silhouette only where `stencil != 1`, i.e. where the actor is genuinely hidden.

Because the gate is **per-pixel** (via the shared stencil) rather than per-fragment, an actor never x-rays through its own body — regardless of body depth, pose, or weapon — with no per-model tuning.

## Scope

The whole fix is self-contained in `OcclusionXrayComponent.cs` + the two new shaders. Doors are unaffected (they keep `door_xray.gdshader`). The discovered-rooms gating, debug toggles, and defaults from #24 are unchanged.

## Verification

- `dotnet build` clean.
- Headless `main.tscn` smoke: map generates, player + enemies spawn, no errors (only the known headless navmesh-bake limitation + shutdown-leak noise).
- Visual check via a temporary windowed screenshot harness on the **orc** (the reported failure): the orc in plain view shows **no** silhouette (self-occlusion gone), while an orc behind a wall shows a clean silhouette through it — and the part of it poking past the wall renders normally. Harness removed afterward.
